### PR TITLE
Adds running flag for ability to report VM slips

### DIFF
--- a/Components/BpfSequencer/BpfSequencer.hpp
+++ b/Components/BpfSequencer/BpfSequencer.hpp
@@ -118,7 +118,7 @@ class BpfSequencer : public BpfSequencerComponentBase {
     
     // Slip detection: atomic integer that stores the VM ID that slipped
     // Value of -1 means no slip detected
-    std::atomic<I32> slip_detected_vm_id{-1};
+    std::array<std::atomic<bool>, k_num_vms> slip_detected{};
     
     // Worker threads
     std::vector<std::thread> workers;

--- a/Components/BpfSequencer/BpfSequencerEvents.fppi
+++ b/Components/BpfSequencer/BpfSequencerEvents.fppi
@@ -39,13 +39,9 @@ event SchedulerQueueFull(vm_id: U32) \
     severity warning high \
     format "Scheduler job queue full, dropping job for VM {}"
 
-event SchedulerSlip(tick: U32) \ 
+event SchedulerSlip(vm_id: U32) \ 
     severity warning high \
-    format "Scheduler slip detected at tick {}"
-
-event VmSlip(vm_id: U32) \
-    severity warning high \
-    format "VM {} slipped, previous execution still running when new job scheduled"
+    format "VM {} slip detected, previous execution still running when new job scheduled"
 
 event WorkerPrioritySetFailed() \
     severity warning high \ 


### PR DESCRIPTION
Fixes #55 

Uses `compare_and_exchange_strong`, `exchange`, and `store`  for atomic operations. 
